### PR TITLE
flag package and readme makeover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+configwalker
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -1,92 +1,83 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/f0wl/configwalker)](https://goreportcard.com/report/github.com/f0wl/configwalker)
+![Go Report Card](https://goreportcard.com/badge/github.com/f0wl/configwalker)
 
 # configwalker
 
-Configwalker is a configuration extractor for Netwalker Ransomware. It is capable of decrypting the RC4 encrypted Resource File and extracting the Ransomnote template. By default it will dump the results to disk, but you can also choose to print the config to stdout only by appending ```--print``` to the command.
+Configwalker is a configuration extractor for Netwalker Ransomware. It is capable of decrypting the RC4 encrypted
+Resource File and extracting the Ransomnote template. By default it will dump the results to disk, but you can also
+choose to print the config to stdout only by appending `-print` to the command.
 
 ## Usage
 
-```go run cfgwalker.go path/to/sample.exe [--print]```
+```shell
+go run cfgwalker.go [-print] path/to/sample.exe
+```
 
-<br>
 
 ## Screenshots
 
-<p align="center">
-  <img src="screenshots/sc.png">
-</p>
+![Screenshot](screenshots/sc.png)
 
-
-<br>
 
 ## Configuration contents
 
 The table below shows the keys used in the JSON configuration of Netwalker Ransomware. 
 
-| Key  | Value / Purpose |
-|:----:|:---------------:|
-| mpk  | Base64 encoded Public Key|
-| mode | Presumably related to the encryption process |
-| spsz | Chunk size for encryption |
-| thr | Threading limit |
-| namesz | Length of the random name for the persistent executable |
-| idsz | Length of the random file extension |
-| pers | Presumably related to target / victim type |
-| mail | Contact e-Mail addresses |
-| onion1 | Main TOR site |
-| onion2 | Backup TOR site |
-| lfile | Template string for the ransomnote filename |
-| lend | Base64 encoded ransomnote template |
-| white{path[ ]} | Whitelist for system directories |
-| white{file[ ]} | Whitelist for system files |
-| white{ext[ ]} | Whitelist for file extensions |
-| kill{use:bool} | Switch to kill specified processes or not |
-| kill{prc[ ]} | List of process names to be terminated |
-| kill{svc[ ]} | List of services to be terminated |
-| kill{svcwait:int} | Timeout before terminating a service |
-| kill{task[ ]} | Task after successful encryption |
-| net{use:bool} | Switch encryption of mapped (network) drives on/off |
-| net{ignore{use:bool}} | Use of Whitelists for drive Encryption |
-| net{ignore{disk:bool}} | Encrypt mounted disks |
-| net{ignore{share[ ]}} | Whitelisted shares |
-| unlocker{use:bool} | Presumably enables decryption capabilities |
-| unlocker{ignore{use:bool}} | Use Ignorelist during decryption |
-| unlocker{ignore{pspath[ ]}} | Process Paths to ignore |
-| unlocker{ignore{prc[ ]}} | Processes to ignore |
-
-<br>
+|             Key             |                     Value / Purpose                     |
+| :-------------------------: | :-----------------------------------------------------: |
+|             mpk             |                Base64 encoded Public Key                |
+|            mode             |      Presumably related to the encryption process       |
+|            spsz             |                Chunk size for encryption                |
+|             thr             |                     Threading limit                     |
+|           namesz            | Length of the random name for the persistent executable |
+|            idsz             |           Length of the random file extension           |
+|            pers             |       Presumably related to target / victim type        |
+|            mail             |                Contact e-Mail addresses                 |
+|           onion1            |                      Main TOR site                      |
+|           onion2            |                     Backup TOR site                     |
+|            lfile            |       Template string for the ransomnote filename       |
+|            lend             |           Base64 encoded ransomnote template            |
+|       white{path[ ]}        |            Whitelist for system directories             |
+|       white{file[ ]}        |               Whitelist for system files                |
+|        white{ext[ ]}        |              Whitelist for file extensions              |
+|       kill{use:bool}        |        Switch to kill specified processes or not        |
+|        kill{prc[ ]}         |         List of process names to be terminated          |
+|        kill{svc[ ]}         |            List of services to be terminated            |
+|      kill{svcwait:int}      |          Timeout before terminating a service           |
+|        kill{task[ ]}        |            Task after successful encryption             |
+|        net{use:bool}        |   Switch encryption of mapped (network) drives on/off   |
+|    net{ignore{use:bool}}    |         Use of Whitelists for drive Encryption          |
+|   net{ignore{disk:bool}}    |                  Encrypt mounted disks                  |
+|    net{ignore{share[ ]}}    |                   Whitelisted shares                    |
+|     unlocker{use:bool}      |       Presumably enables decryption capabilities        |
+| unlocker{ignore{use:bool}}  |            Use Ignorelist during decryption             |
+| unlocker{ignore{pspath[ ]}} |                 Process Paths to ignore                 |
+|  unlocker{ignore{prc[ ]}}   |                   Processes to ignore                   |
 
 ## Background Info
 
-Not all samples of Netwalker Ransomware will contain a full configuration file. Below you can see two screenshots of Resource Hacker, one with an long encrypted config and one with a short plaintext config. This tool only works for the former format.
+Not all samples of Netwalker Ransomware will contain a full configuration file. Below you can see two screenshots of
+Resource Hacker, one with an long encrypted config and one with a short plaintext config. This tool only works for
+the former format.
 
-<p align="center">
-  <img src="screenshots/encrypted-config.png">
-</p>
+![Screenshot of encrypted config](screenshots/encrypted-config.png)
 
-<p align="center">
-  <img src="screenshots/plain-config.png">
-</p>
+![Screenshot of plain config](screenshots/plain-config.png)
 
-<br>
+The first 4 Bytes of the resource ("1337/31337/0") contain the length of the RC4 Key. This value changes from sample
+to sample. With this information it is easy to extract the key and decrypt the rest of the resource.
 
-The first 4 Bytes of the resource ("1337/31337/0") contain the length of the RC4 Key. This value changes from sample to sample. With this information it is easy to extract the key and decrypt the rest of the resource.
-
-<p align="center">
-  <img src="screenshots/hexeditor.png">
-</p>
-
-<br>
+![Screenshot of hexeditor](screenshots/hexeditor.png)
 
 ## Testing
 
-The tool has been confirmed to successfully extract the configuration from the following samples identifiable by their SHA-256 hashsums. If you encounter an error with configwalker please file a bug report via an issue. On some occasions the Netwalker config files contain malformed json objects which may cause configwalker to crash (fix WIP).
+The tool has been confirmed to successfully extract the configuration from the following samples identifiable by
+their SHA-256 hashsums. If you encounter an error with configwalker please file a bug report via an issue. On some
+occasions the Netwalker config files contain malformed json objects which may cause configwalker to crash (fix WIP).
 
-
-| SHA-256 Hashsums| Sample |
-|:---------------:|:------:| 
-| 1707f8647515bc7a686e7aed380ab06dd6b853b908ae98252c1e8eefa1e1d540 | [MalwareBazaar](https://bazaar.abuse.ch/sample/1707f8647515bc7a686e7aed380ab06dd6b853b908ae98252c1e8eefa1e1d540/) |
-| 5d869c0e077596bf0834f08dce062af1477bf09c8f6aa0a45d6a080478e45512 | [MalwareBazaar](https://bazaar.abuse.ch/sample/5d869c0e077596bf0834f08dce062af1477bf09c8f6aa0a45d6a080478e45512/) |
-| 46dbb7709411b1429233e0d8d33a02cccd54005a2b4015dcfa8a890252177df9 |[MalwareBazaar](https://bazaar.abuse.ch/sample/46dbb7709411b1429233e0d8d33a02cccd54005a2b4015dcfa8a890252177df9/) |
-| 4f7bdda79e389d6660fca8e2a90a175307a7f615fa7673b10ee820d9300b5c60 | [MalwareBazaar](https://bazaar.abuse.ch/sample/4f7bdda79e389d6660fca8e2a90a175307a7f615fa7673b10ee820d9300b5c60/) |
-| 27319e75c23693399977e92b9a7ba5680a7a9db448f93b3221840c61301604d5 | [MalwareBazaar](https://bazaar.abuse.ch/sample/27319e75c23693399977e92b9a7ba5680a7a9db448f93b3221840c61301604d5/) |
+|                          SHA-256 Hashsums                          |                                                      Sample                                                       |
+| :----------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------: |
+| `1707f8647515bc7a686e7aed380ab06dd6b853b908ae98252c1e8eefa1e1d540` | [MalwareBazaar](https://bazaar.abuse.ch/sample/1707f8647515bc7a686e7aed380ab06dd6b853b908ae98252c1e8eefa1e1d540/) |
+| `5d869c0e077596bf0834f08dce062af1477bf09c8f6aa0a45d6a080478e45512` | [MalwareBazaar](https://bazaar.abuse.ch/sample/5d869c0e077596bf0834f08dce062af1477bf09c8f6aa0a45d6a080478e45512/) |
+| `46dbb7709411b1429233e0d8d33a02cccd54005a2b4015dcfa8a890252177df9` | [MalwareBazaar](https://bazaar.abuse.ch/sample/46dbb7709411b1429233e0d8d33a02cccd54005a2b4015dcfa8a890252177df9/) |
+| `4f7bdda79e389d6660fca8e2a90a175307a7f615fa7673b10ee820d9300b5c60` | [MalwareBazaar](https://bazaar.abuse.ch/sample/4f7bdda79e389d6660fca8e2a90a175307a7f615fa7673b10ee820d9300b5c60/) |
+| `27319e75c23693399977e92b9a7ba5680a7a9db448f93b3221840c61301604d5` | [MalwareBazaar](https://bazaar.abuse.ch/sample/27319e75c23693399977e92b9a7ba5680a7a9db448f93b3221840c61301604d5/) |

--- a/cfgwalker.go
+++ b/cfgwalker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,6 +33,10 @@ func rc4decrypt(extkey []byte, data []byte) []byte {
 	return data
 }
 
+var (
+	verboseFlag bool
+)
+
 func main() {
 
 	fmt.Printf("\n\n     ,-----.,------. ,----.   ,--.   ,--.        ,--.,--.                  \n")
@@ -42,13 +47,15 @@ func main() {
 	fmt.Printf("\n                Netwalker Ransomware Configuration Extractor\n")
 	fmt.Printf("            Marius 'f0wL' Genheimer | https://dissectingmalwa.re\n\n\n")
 
-	if len(os.Args) < 2 {
-		fmt.Println("   Usage: go run cfgwalker.go netwalker_sample.exe [--print (write to stdout instead of a file)]")
+	flag.BoolVar(&verboseFlag, "print", false, "Print config to stdout")
+	flag.Parse()
+	if flag.NArg() == 0 {
+			fmt.Printf(Sprintf(Red(" [!] Error: No path to sample provided\n\n")))
 		os.Exit(1)
 	}
 
 	// open the sample with pefile
-	f, openErr := pefile.Open(os.Args[1])
+	f, openErr := pefile.Open(flag.Args()[0])
 	check(openErr)
 	defer f.Close()
 	// Fetch resources from the PE
@@ -71,7 +78,7 @@ func main() {
 		}
 	}
 
-	if len(os.Args) < 2 {
+	if !verboseFlag{
 		// write encrypted resource to file for safe-keeping
 		writeErr := ioutil.WriteFile("config.enc", encryptedData, 0644)
 		check(writeErr)
@@ -96,7 +103,7 @@ func main() {
 	jsonErr := json.Indent(&out, config, "", "  ")
 	check(jsonErr)
 
-	if len(os.Args) > 2 && os.Args[2] == "--print" {
+	if verboseFlag {
 		fmt.Printf(Sprintf(Green(" [+] Decrypted JSON Config: \n\n")))
 		fmt.Printf("%v\n\n", out.String())
 	} else {
@@ -120,7 +127,7 @@ func main() {
 	decodedNote, base64Err := base64.StdEncoding.DecodeString(ransomnote.(string))
 	check(base64Err)
 
-	if len(os.Args) > 2 && os.Args[2] == "--print" {
+	if verboseFlag{
 		fmt.Printf(Sprintf(Green("\n\n [+] Extracted and base64 decoded Ransomnote:\n\n")))
 		fmt.Printf(string(decodedNote) + "\n\n")
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/f0wl/configwalker
+
+go 1.15
+
+require (
+	github.com/folbricht/pefile v0.1.0
+	github.com/logrusorgru/aurora v2.0.3+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/folbricht/pefile v0.1.0 h1:y9aMwgNlPO/iyp8Izll3Au4XNp7Fi7uDH8OKZ1Nl+lw=
+github.com/folbricht/pefile v0.1.0/go.mod h1:QP4MiHKu0BG/jiftQCJoiH+mM1UMNncR3S+HeioLtvc=
+github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
+github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=


### PR DESCRIPTION
Heyho,

I added the `flag` package for easier handling of the print flag. I also remove the HTML from the README and used plain markdown to include the screenshoots and formatted the table and the textwidth for easier editting/reading.
Lastly I added the go module files to track the dependencies.